### PR TITLE
Simple support for clojurescript files

### DIFF
--- a/Syntaxes/Clojure.tmLanguage
+++ b/Syntaxes/Clojure.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>clj</string>
+		<string>cljs</string>
 		<string>clojure</string>
 	</array>
 	<key>foldingStartMarker</key>


### PR DESCRIPTION
Nothing more than adding the 'cljs' extension to the bundle so I can use TextMate to hack on clojurescript as well.

Thanks!
